### PR TITLE
Add fi locale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ names.am                  // => 'vormittags'
 names.pm                  // => 'nachmittags'
 ```
 
-English ([en](en.js)) and German ([de](de.js)) are currently the only supported locales. Pull requests welcome.
+English ([en](en.js)), German ([de](de.js)) and Finnish ([fi](fi.js)) are currently the only supported locales. Pull requests welcome.
 
 
 ## Contributing

--- a/fi.js
+++ b/fi.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+  __locale: "fi",
+  days: ['Sunnuntai', 'Maanantai', 'Tiistai', 'Keskiviikko', 'Torstai', 'Perjantai', 'Lauantai'],
+  abbreviated_days: ['Su', 'Ma', 'Ti', 'Ke', 'To', 'Pe', 'La'],
+  months: ['Tammikuu', 'Helmikuu', 'Maaliskuu', 'Huhtikuu', 'Toukokuu', 'Kesäkuu', 'Heinäkuu', 'Elokuu', 'Syyskuu', 'Lokakuu', 'Marraskuu', 'Joulukuu'],
+  abbreviated_months: ['Tammi', 'Helmi', 'Maalis', 'Huhti', 'Touko', 'Kesä', 'Heinä', 'Elo', 'Syys', 'Loka', 'Marras', 'Joulu'],
+  am: 'a.m.',
+  pm: 'p.m.'
+};

--- a/spec.js
+++ b/spec.js
@@ -3,6 +3,7 @@ var hasKey  = Object.prototype.hasOwnProperty;
 
 testLocale('en');
 testLocale('de');
+testLocale('fi');
 
 function testLocale(locale, path, name) {
   path = path || ('./' + locale);


### PR DESCRIPTION
Add support for Finnish names. 

Note that this has capitalized days and months even though they are not capitalized when used in the Finnish language—is this ok?
