### PR TITLE
Add "use strict" to make tests pass

### DIFF
--- a/de.js
+++ b/de.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
   __locale: "de",
   days: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],

--- a/en.js
+++ b/en.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
   __locale: "en",
   days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
+"use strict";
 module.exports = require('./en');


### PR DESCRIPTION
`make test` fails due to missing "use strict".
