### PR TITLE
add Indonesian(id) locale support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test: lint
 	@$(BIN)/mocha -t 5000 -b -R spec spec.js
 
 lint:
-	@$(BIN)/jshint index.js cs.js da.js de.js en.js es.js fi.js fr.js nl.js pt-br.js ru.js sk.js sv.js tr.js
+	@$(BIN)/jshint index.js cs.js da.js de.js en.js es.js fi.js fr.js nl.js pt-br.js ru.js sk.js sv.js tr.js id.js
 
 install:
 	npm install

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ names.am                  // => 'vormittags'
 names.pm                  // => 'nachmittags'
 ```
 
-Brazilian Portuguese ([pt-br](pt-br.js)), Czech ([cs](cs.js)), Danish ([da](da.js)), Dutch ([nl](nl.js)), English ([en](en.js)), Finnish ([fi](fi.js)), French ([fr](fr.js)), German ([de](de.js)), Spanish ([es](es.js)), Russian ([ru](ru.js)), Slovak ([sk](sk.js)), Swedish ([sv](sv.js)) and Turkish ([tr](tr.js)) are currently the only supported locales. Pull requests welcome.
+Brazilian Portuguese ([pt-br](pt-br.js)), Czech ([cs](cs.js)), Danish ([da](da.js)), Dutch ([nl](nl.js)), English ([en](en.js)), Finnish ([fi](fi.js)), French ([fr](fr.js)), German ([de](de.js)), Spanish ([es](es.js)), Russian ([ru](ru.js)), Slovak ([sk](sk.js)), Swedish ([sv](sv.js)), Turkish ([tr](tr.js)), and Indonesian ([id](id.js)) are currently the only supported locales. Pull requests welcome.
 
 
 ## Contributing

--- a/id.js
+++ b/id.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+  __locale: "id",
+  days: ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu'],
+  abbreviated_days: ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
+  months: ['Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni', 'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember'],
+  abbreviated_months: ['Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun', 'Jul', 'Agu', 'Sep', 'Okt', 'Nov', 'Des'],
+  am: 'Pagi',
+  pm: 'Petang'
+};

--- a/spec.js
+++ b/spec.js
@@ -14,6 +14,7 @@ testLocale('ru');
 testLocale('sk');
 testLocale('sv');
 testLocale('tr');
+testLocale('id');
 
 function testLocale(locale, path, name) {
   path = path || ('./' + locale);


### PR DESCRIPTION
Hi there! I've added Indonesian (id) locale support. Things to note though, we Indonesian use a 24-hour clock. So in 'AM' and 'PM', I use 'pagi' and 'petang' which means morning and afternoon/evening respectively.